### PR TITLE
Try to fix #17 - Non-copy-constructibility tests fail

### DIFF
--- a/include/strf/destination.hpp
+++ b/include/strf/destination.hpp
@@ -287,39 +287,18 @@ public:
              , std::enable_if_t
                  < std::is_copy_constructible<T>::value, int > = 0 >
     constexpr STRF_HD destination_no_reserve( strf::detail::destination_tag
-                                    , const OutbufCreator& oc
-                                    , const FPack& fp )
+                                            , const OutbufCreator& oc
+                                            , const FPack& fp )
         : _outbuf_creator(oc)
         , _fpack(fp)
     {
     }
 
     constexpr STRF_HD destination_no_reserve( strf::detail::destination_tag
-                                    , OutbufCreator&& oc
-                                    , FPack&& fp )
+                                            , OutbufCreator&& oc
+                                            , FPack&& fp )
         : _outbuf_creator(std::move(oc))
         , _fpack(std::move(fp))
-    {
-    }
-
-    constexpr STRF_HD destination_no_reserve(const destination_no_reserve& other)
-        : strf::detail::destination_common
-            < strf::destination_no_reserve
-            , OutbufCreator
-            , FPack
-            , strf::print_preview<false, false> >(other)
-        , _outbuf_creator(other._outbuf_creator)
-        , _fpack(other._fpack)
-    {
-    }
-    constexpr STRF_HD destination_no_reserve(destination_no_reserve&& other)
-        : strf::detail::destination_common
-            < strf::destination_no_reserve
-            , OutbufCreator
-            , FPack
-            , strf::print_preview<false, false> >(other)
-        , _outbuf_creator(other._outbuf_creator)
-        , _fpack(other._fpack)
     {
     }
 
@@ -425,9 +404,9 @@ public:
     template < typename T = OutbufCreator
              , std::enable_if_t<std::is_copy_constructible<T>::value, int> = 0 >
     constexpr STRF_HD destination_with_given_size( strf::detail::destination_tag
-                                         , std::size_t size
-                                         , const OutbufCreator& oc
-                                         , const FPack& fp )
+                                                 , std::size_t size
+                                                 , const OutbufCreator& oc
+                                                 , const FPack& fp )
         : _size(size)
         , _outbuf_creator(oc)
         , _fpack(fp)
@@ -435,39 +414,14 @@ public:
     }
 
     constexpr STRF_HD destination_with_given_size( strf::detail::destination_tag
-                                         , std::size_t size
-                                         , OutbufCreator&& oc
-                                         , FPack&& fp )
+                                                 , std::size_t size
+                                                 , OutbufCreator&& oc
+                                                 , FPack&& fp )
         : _size(size)
         , _outbuf_creator(std::move(oc))
         , _fpack(std::move(fp))
     {
     }
-
-    constexpr STRF_HD destination_with_given_size(const destination_with_given_size& other)
-        : strf::detail::destination_common
-            < strf::destination_with_given_size
-            , OutbufCreator
-            , FPack
-            , strf::print_preview<false, false> >(other)
-        , _size(other._size)
-        , _outbuf_creator(other._outbuf_creator)
-        , _fpack(other._fpack)
-    {
-    }
-
-    constexpr STRF_HD destination_with_given_size(destination_with_given_size&& other)
-        : strf::detail::destination_common
-            < strf::destination_with_given_size
-            , OutbufCreator
-            , FPack
-            , strf::print_preview<false, false> >(other)
-        , _size(other._size)
-        , _outbuf_creator(other._outbuf_creator)
-        , _fpack(other._fpack)
-    {
-    }
-
 
     using _common::with;
     using _common::operator();
@@ -568,40 +522,18 @@ public:
              , std::enable_if_t
                  < std::is_copy_constructible<T>::value, int > = 0 >
     constexpr STRF_HD destination_calc_size( strf::detail::destination_tag
-                                   , const OutbufCreator& oc
-                                   , const FPack& fp )
+                                           , const OutbufCreator& oc
+                                           , const FPack& fp )
         : _outbuf_creator(oc)
         , _fpack(fp)
     {
     }
 
     constexpr STRF_HD destination_calc_size( strf::detail::destination_tag
-                                   , OutbufCreator&& oc
-                                   , FPack&& fp )
+                                           , OutbufCreator&& oc
+                                           , FPack&& fp )
         : _outbuf_creator(std::move(oc))
         , _fpack(std::move(fp))
-    {
-    }
-
-    constexpr STRF_HD destination_calc_size(const destination_calc_size& other)
-        : strf::detail::destination_common
-            < strf::destination_calc_size
-            , OutbufCreator
-            , FPack
-            , strf::print_preview<true, false> >(other)
-        , _outbuf_creator(other._outbuf_creator)
-        , _fpack(other._fpack)
-    {
-    }
-
-    constexpr STRF_HD destination_calc_size(destination_calc_size&& other)
-        : strf::detail::destination_common
-            < strf::destination_calc_size
-            , OutbufCreator
-            , FPack
-            , strf::print_preview<true, false> >(other)
-        , _outbuf_creator(other._outbuf_creator)
-        , _fpack(other._fpack)
     {
     }
 

--- a/include/strf/detail/common.hpp
+++ b/include/strf/detail/common.hpp
@@ -208,25 +208,25 @@ strlen( const char* str )
 
 struct absolute_lowest_rank
 {
-        explicit constexpr STRF_HD absolute_lowest_rank() noexcept { };
+    explicit constexpr STRF_HD absolute_lowest_rank() noexcept { };
 };
 
 template <std::size_t N>
 struct rank: rank<N - 1>
 {
-        explicit constexpr STRF_HD rank() noexcept { };
+    explicit constexpr STRF_HD rank() noexcept { };
 };
 
 template <>
 struct rank<0>: absolute_lowest_rank
 {
-        explicit constexpr STRF_HD rank() noexcept { }
+    explicit constexpr STRF_HD rank() noexcept { }
 };
 
 template <typename ... >
 struct tag
 {
-        explicit constexpr STRF_HD tag() noexcept { }
+    explicit constexpr STRF_HD tag() noexcept { }
 };
 
 STRF_NAMESPACE_END

--- a/include/strf/detail/facets/encoding.hpp
+++ b/include/strf/detail/facets/encoding.hpp
@@ -275,9 +275,6 @@ public:
     {
     }
 
-        constexpr STRF_HD transcoder(const transcoder& other) noexcept
-        : transcoder(other._impl) { }
-
     transcoder& operator=(const transcoder& cp) noexcept
     {
         _impl = cp._impl;

--- a/include/strf/detail/facets/numpunct.hpp
+++ b/include/strf/detail/facets/numpunct.hpp
@@ -22,9 +22,6 @@ public:
         STRF_ASSERT(_groups_size != 0);
     }
 
-        constexpr STRF_HD monotonic_grouping_impl(const monotonic_grouping_impl& other) noexcept
-        : monotonic_grouping_impl(other._groups_size) { }
-
     STRF_HD unsigned get_thousands_sep_count(unsigned num_digits) const
     {
         return (_groups_size == 0 || num_digits == 0)
@@ -245,7 +242,7 @@ public:
 
 protected:
 
-        STRF_HD numpunct(const numpunct& other) noexcept
+    STRF_HD numpunct(const numpunct& other) noexcept
         : strf::numpunct_base(other) { }
 };
 
@@ -296,13 +293,8 @@ public:
     {
     }
 
-        constexpr STRF_HD monotonic_grouping(const monotonic_grouping& other)
-        : strf::numpunct<Base>(other), _impl(other._impl)
-    {
-    }
-
     STRF_HD unsigned groups( unsigned num_digits
-                   , std::uint8_t* groups_array ) const override
+                           , std::uint8_t* groups_array ) const override
     {
         auto s = _impl.get_groups(num_digits, groups_array) - groups_array;
         return 1 + static_cast<unsigned>(s);
@@ -354,7 +346,7 @@ public:
 
     str_grouping(const str_grouping&) = default;
 
-    str_grouping(str_grouping&& other) = default;
+    str_grouping(str_grouping&&) = default;
 
     unsigned groups( unsigned num_digits
                    , std::uint8_t* groups_array ) const override

--- a/include/strf/detail/facets/width_calculator.hpp
+++ b/include/strf/detail/facets/width_calculator.hpp
@@ -37,7 +37,7 @@ class fast_width final: public strf::width_calculator<CharT>
 {
 public:
 
-	STRF_HD strf::width_t width_of
+    STRF_HD strf::width_t width_of
         ( CharT ch, strf::encoding<CharT> enc ) const override
     {
         (void)ch;
@@ -45,7 +45,7 @@ public:
         return 1;
     }
 
-	STRF_HD strf::width_t width
+    STRF_HD strf::width_t width
         ( strf::width_t limit
         , const CharT* str
         , std::size_t str_len

--- a/include/strf/detail/format_functions.hpp
+++ b/include/strf/detail/format_functions.hpp
@@ -102,19 +102,6 @@ public:
     {
     }
 
-    constexpr STRF_HD value_with_format(const value_with_format& other)
-        : Fmts::template fn<value_with_format<ValueType, Fmts...>>(other)
-        ...
-        , _value(other._value)
-    {
-    }
-    constexpr STRF_HD value_with_format(value_with_format&& other)
-        : Fmts::template fn<value_with_format<ValueType, Fmts...>>(other)
-        ...
-        , _value(other._value)
-    {
-    }
-
     template <typename OtherValueType>
     constexpr STRF_HD value_with_format
         ( const ValueType& v

--- a/include/strf/detail/input_types/cv_string.hpp
+++ b/include/strf/detail/input_types/cv_string.hpp
@@ -81,7 +81,7 @@ public:
         , strf::encoding_error enc_err
         , strf::surrogate_policy allow_surr ) noexcept;
 
-        STRF_HD ~cv_string_printer() { }
+    STRF_HD ~cv_string_printer() { }
 
     STRF_HD std::size_t necessary_size() const;
 

--- a/include/strf/detail/input_types/facets_pack.hpp
+++ b/include/strf/detail/input_types/facets_pack.hpp
@@ -50,7 +50,7 @@ class facets_pack_printer: public strf::printer<CharT>
 {
 public:
 
-	STRF_HD facets_pack_printer
+	  STRF_HD facets_pack_printer
         ( const ParentFPack& parent_fp
         , Preview& preview
         , const strf::inner_pack_with_args<ChildFPack, Args...>& args )

--- a/include/strf/detail/input_types/float.hpp
+++ b/include/strf/detail/input_types/float.hpp
@@ -333,16 +333,6 @@ namespace detail {
 
 struct double_printer_data: detail::double_dec
 {
-        constexpr STRF_HD double_printer_data(const double_printer_data& other)
-        : double_dec(other)
-        , showpoint(other.showpoint)
-        , showsign(other.showsign)
-        , sci_notation(other.sci_notation)
-        , m10_digcount(other.m10_digcount)
-        , extra_zeros(other.extra_zeros)
-    {
-    }
-
     template <typename FloatT>
     STRF_HD double_printer_data
         ( FloatT f

--- a/include/strf/detail/input_types/int.hpp
+++ b/include/strf/detail/input_types/int.hpp
@@ -54,7 +54,7 @@ private:
 
 public:
 
-        constexpr STRF_HD int_format_fn()  noexcept { }
+    constexpr STRF_HD int_format_fn()  noexcept { }
 
     template <typename U, int OtherBase>
     constexpr STRF_HD int_format_fn(const int_format_fn<U, OtherBase> & u) noexcept

--- a/include/strf/detail/input_types/join.hpp
+++ b/include/strf/detail/input_types/join.hpp
@@ -25,421 +25,490 @@ template<typename T>
 class split_pos_format_fn<true, T> {
 public:
 
-	constexpr STRF_HD split_pos_format_fn() noexcept
-	{
-	}
-	;
+    constexpr STRF_HD split_pos_format_fn() noexcept
+    {
+    }
 
-	constexpr STRF_HD explicit split_pos_format_fn(std::ptrdiff_t pos) noexcept
-	: _pos(pos)
-	{
-	}
-	constexpr STRF_HD split_pos_format_fn(const split_pos_format_fn& other) noexcept
-	: split_pos_format_fn(other._pos)
-	{
-	}
+    constexpr STRF_HD explicit split_pos_format_fn(std::ptrdiff_t pos) noexcept
+        : _pos(pos)
+    {
+    }
+    constexpr STRF_HD split_pos_format_fn(const split_pos_format_fn& other) noexcept
+        : split_pos_format_fn(other._pos)
+    {
+    }
 
-	template <bool B, typename U>
-	constexpr STRF_HD explicit split_pos_format_fn
-	( const split_pos_format_fn<B,U>& r ) noexcept
-	: _pos(r.split_pos())
-	{
-	}
+    template <bool B, typename U>
+    constexpr STRF_HD explicit split_pos_format_fn
+        ( const split_pos_format_fn<B,U>& r ) noexcept
+        : _pos(r.split_pos())
+    {
+    }
 
-	constexpr STRF_HD T&& split_pos(std::ptrdiff_t pos) && noexcept
-	{
-		_pos = pos;
-		return static_cast<T&&>(*this);
-	}
+    constexpr STRF_HD T&& split_pos(std::ptrdiff_t pos) && noexcept
+    {
+        _pos = pos;
+        return static_cast<T&&>(*this);
+    }
 
-	constexpr STRF_HD std::ptrdiff_t split_pos() const noexcept
-	{
-		return _pos;
-	}
+    constexpr STRF_HD std::ptrdiff_t split_pos() const noexcept
+    {
+        return _pos;
+    }
 
 private:
 
-	std::ptrdiff_t _pos = 0;
+    std::ptrdiff_t _pos = 0;
 };
 
 template<typename T>
-class split_pos_format_fn<false, T> {
-	using _adapted_derived_type = strf::fmt_replace
-	< T
-	, strf::split_pos_format<false>
-	, strf::split_pos_format<true> >;
+class split_pos_format_fn<false, T>
+{
+    using _adapted_derived_type = strf::fmt_replace
+        < T
+        , strf::split_pos_format<false>
+        , strf::split_pos_format<true> >;
 public:
 
-	constexpr STRF_HD split_pos_format_fn() noexcept
-	{
-	}
-	constexpr STRF_HD split_pos_format_fn(const split_pos_format_fn& other) noexcept
-	{
-	}
+    constexpr STRF_HD split_pos_format_fn() noexcept
+    {
+    }
+    constexpr STRF_HD split_pos_format_fn(const split_pos_format_fn& other) noexcept
+    {
+    }
 
-	template<typename U>
-	constexpr STRF_HD explicit split_pos_format_fn(const strf::split_pos_format_fn<false, U>&) noexcept
-	{
-	}
+    template<typename U>
+    constexpr STRF_HD explicit split_pos_format_fn(const strf::split_pos_format_fn<false, U>&) noexcept
+    {
+    }
 
-	constexpr STRF_HD _adapted_derived_type split_pos(std::ptrdiff_t pos) const noexcept
-	{
-		return {static_cast<const T&>(*this)
-			, strf::tag<strf::split_pos_format<true>> {}
-			, pos};
-	}
+    constexpr STRF_HD _adapted_derived_type split_pos(std::ptrdiff_t pos) const noexcept
+    {
+        return {static_cast<const T&>(*this)
+            , strf::tag<strf::split_pos_format<true>> {}
+            , pos};
+    }
 
-	constexpr STRF_HD std::ptrdiff_t split_pos() const noexcept
-	{
-		return 0;
-	}
+    constexpr STRF_HD std::ptrdiff_t split_pos() const noexcept
+    {
+        return 0;
+    }
 };
 
 template<bool Active>
-struct split_pos_format {
-	template<typename T>
-	using fn = strf::split_pos_format_fn<Active, T>;
+struct split_pos_format
+{
+    template<typename T>
+    using fn = strf::split_pos_format_fn<Active, T>;
 };
 
-struct aligned_join_t {
-	std::int16_t width = 0;
-	strf::text_alignment align = strf::text_alignment::right;
-	char32_t fillchar = U' ';
-	std::ptrdiff_t split_pos = 1;
+struct aligned_join_t
+{
+    std::int16_t width = 0;
+    strf::text_alignment align = strf::text_alignment::right;
+    char32_t fillchar = U' ';
+    std::ptrdiff_t split_pos = 1;
 
-	template<typename ... Args>
-	constexpr STRF_HD strf::value_with_format<strf::detail::simple_tuple<strf::detail::opt_val_or_cref<Args>...>,
-		strf::split_pos_format<true>, strf::alignment_format_q<true> > operator()(const Args& ... args) const
-	{
-		return {strf::detail::make_simple_tuple<Args...>(args...)
-			, strf::tag< strf::split_pos_format<true>
-			, strf::alignment_format_q<true> > {}
-			, split_pos
-			, strf::alignment_format_data {fillchar, width, align}};
-	}
+    template<typename ... Args>
+    constexpr STRF_HD strf::value_with_format
+        < strf::detail::simple_tuple< strf::detail::opt_val_or_cref<Args>...>
+                                    , strf::split_pos_format<true>
+                                    , strf::alignment_format_q<true> >
+    operator()(const Args& ... args) const
+    {
+        return { strf::detail::make_simple_tuple<Args...>(args...)
+               , strf::tag< strf::split_pos_format<true>
+               , strf::alignment_format_q<true> > {}
+               , split_pos
+               , strf::alignment_format_data {fillchar, width, align}};
+    }
 };
 
 namespace detail {
 
 template<typename CharT>
-STRF_HD void print_split(strf::basic_outbuf<CharT>& ob, strf::encoding<CharT> enc, unsigned fillcount, char32_t fillchar,
-	std::ptrdiff_t split_pos, strf::encoding_error enc_err, strf::surrogate_policy allow_surr)
+STRF_HD void print_split
+    ( strf::basic_outbuf<CharT>& ob
+    , strf::encoding<CharT> enc
+    , unsigned fillcount
+    , char32_t fillchar
+    , std::ptrdiff_t split_pos
+    , strf::encoding_error enc_err
+    , strf::surrogate_policy allow_surr)
 {
-	(void) split_pos;
-	enc.encode_fill(ob, fillcount, fillchar, enc_err, allow_surr);
+    (void) split_pos;
+    enc.encode_fill(ob, fillcount, fillchar, enc_err, allow_surr);
 }
 
 template<typename CharT, typename Printer, typename ... Printers>
-STRF_HD void print_split(strf::basic_outbuf<CharT>& ob, strf::encoding<CharT> enc, unsigned fillcount, char32_t fillchar,
-	std::ptrdiff_t split_pos, strf::encoding_error enc_err, strf::surrogate_policy allow_surr, const Printer& p,
-	const Printers& ... printers)
+STRF_HD void print_split
+    ( strf::basic_outbuf<CharT>& ob
+    , strf::encoding<CharT> enc
+    , unsigned fillcount
+    , char32_t fillchar
+    , std::ptrdiff_t split_pos
+    , strf::encoding_error enc_err
+    , strf::surrogate_policy allow_surr
+    , const Printer& p
+    , const Printers& ... printers )
 {
-	if (split_pos > 0) {
-		p.print_to(ob);
-		print_split(ob, enc, fillcount, fillchar, split_pos - 1, enc_err, allow_surr, printers...);
-	} else {
-		enc.encode_fill(ob, fillcount, fillchar, enc_err, allow_surr);
-		strf::detail::write_args(ob, p, printers...);
-	}
+    if (split_pos > 0) {
+        p.print_to(ob);
+        print_split(ob, enc, fillcount, fillchar, split_pos - 1, enc_err, allow_surr, printers...);
+    } else {
+        enc.encode_fill(ob, fillcount, fillchar, enc_err, allow_surr);
+        strf::detail::write_args(ob, p, printers...);
+    }
 }
 
 template<typename CharT, std::size_t ... I, typename ... Printers>
-STRF_HD void print_split(const strf::detail::printers_tuple_impl<CharT, std::index_sequence<I...>, Printers...>& printers,
-	strf::basic_outbuf<CharT>& ob, strf::encoding<CharT> enc, unsigned fillcount, char32_t fillchar,
-	std::ptrdiff_t split_pos, strf::encoding_error enc_err, strf::surrogate_policy allow_surr)
+STRF_HD void print_split
+    ( const strf::detail::printers_tuple_impl
+        < CharT, std::index_sequence<I...>, Printers... >& printers
+    , strf::basic_outbuf<CharT>& ob
+    , strf::encoding<CharT> enc
+    , unsigned fillcount
+    , char32_t fillchar
+    , std::ptrdiff_t split_pos
+    , strf::encoding_error enc_err
+    , strf::surrogate_policy allow_surr )
 {
-	strf::detail::print_split(ob, enc, fillcount, fillchar, split_pos, enc_err, allow_surr,
-		printers.template get<I>()...);
+    strf::detail::print_split( ob, enc, fillcount, fillchar, split_pos, enc_err
+                             , allow_surr, printers.template get<I>()... );
 }
 
 template<typename CharT, typename ... Printers>
-class aligned_join_printer_impl: public printer<CharT> {
-	using _printers_tuple = strf::detail::printers_tuple<CharT, Printers...>;
+class aligned_join_printer_impl: public printer<CharT>
+{
+    using _printers_tuple = strf::detail::printers_tuple<CharT, Printers...>;
 
 public:
 
-	template<typename FPack, bool ReqSize, typename ... Args>
-	STRF_HD aligned_join_printer_impl(const FPack& fp, strf::print_preview<ReqSize, false>& preview,
-		const strf::detail::simple_tuple<Args...>& args, std::ptrdiff_t split_pos, strf::alignment_format_data afmt) :
-		_split_pos(split_pos), _afmt(afmt), _encoding(_get_facet<strf::encoding_c<CharT>>(fp)),
-			_enc_err(_get_facet<strf::encoding_error_c>(fp)), _allow_surr(_get_facet<strf::surrogate_policy_c>(fp))
-	{
-		strf::print_preview<ReqSize, true> p { _afmt.width };
-		new (_printers_ptr()) _printers_tuple { fp, p, args };
-		if (p.remaining_width() > 0) {
-			_fillcount = p.remaining_width().round();
-		}
-		STRF_IF_CONSTEXPR (ReqSize)
-			{
-				preview.add_size(p.get_size());
-				if (_fillcount > 0) {
-					auto fcharsize = _encoding.char_size(_afmt.fill);
-					preview.add_size(_fillcount * fcharsize);
-				}
-			}
-			(void) preview;
-		}
+    template<typename FPack, bool ReqSize, typename ... Args>
+    STRF_HD aligned_join_printer_impl
+        ( const FPack& fp
+        , strf::print_preview<ReqSize, false>& preview
+        , const strf::detail::simple_tuple<Args...>& args
+        , std::ptrdiff_t split_pos
+        , strf::alignment_format_data afmt )
+        : _split_pos(split_pos)
+        , _afmt(afmt)
+        , _encoding(_get_facet<strf::encoding_c<CharT>>(fp))
+        , _enc_err(_get_facet<strf::encoding_error_c>(fp))
+        , _allow_surr(_get_facet<strf::surrogate_policy_c>(fp))
+    {
+        strf::print_preview<ReqSize, true> p { _afmt.width };
+        new (_printers_ptr()) _printers_tuple { fp, p, args };
+        if (p.remaining_width() > 0) {
+            _fillcount = p.remaining_width().round();
+        }
+        STRF_IF_CONSTEXPR (ReqSize) {
+            preview.add_size(p.get_size());
+            if (_fillcount > 0) {
+                auto fcharsize = _encoding.char_size(_afmt.fill);
+                preview.add_size(_fillcount * fcharsize);
+            }
+        }
+        (void) preview;
+    }
 
-	template<typename FPack, bool ReqSize, typename ... Args>
-	STRF_HD aligned_join_printer_impl(const FPack& fp, strf::print_preview<ReqSize, true>& preview,
-		const strf::detail::simple_tuple<Args...>& args, std::ptrdiff_t split_pos, strf::alignment_format_data afmt) :
-		_split_pos(split_pos), _afmt(afmt), _encoding(_get_facet<strf::encoding_c<CharT>>(fp)),
-			_enc_err(_get_facet<strf::encoding_error_c>(fp)), _allow_surr(_get_facet<strf::surrogate_policy_c>(fp))
-	{
-		if (_afmt.width < 0) {
-			_afmt.width = 0;
-		}
-		strf::width_t wmax = _afmt.width;
-		strf::width_t diff = 0;
-		if (preview.remaining_width() > _afmt.width) {
-			wmax = preview.remaining_width();
-			diff = preview.remaining_width() - _afmt.width;
-		}
-		strf::print_preview<ReqSize, true> p { wmax };
-		new (_printers_ptr()) _printers_tuple { fp, p, args }; // todo: what if this throws ?
-		if (p.remaining_width() > diff) {
-			_fillcount = (p.remaining_width() - diff).round();
-		}
-		width_t width = _fillcount + wmax - p.remaining_width();
-		preview.subtract_width(width);
-		STRF_IF_CONSTEXPR (ReqSize)
-			{
-				preview.add_size(p.get_size());
-				if (_fillcount > 0) {
-					preview.add_size(_fillcount * _encoding.char_size(_afmt.fill));
-				}
-			}
-		}
+    template<typename FPack, bool ReqSize, typename ... Args>
+    STRF_HD aligned_join_printer_impl
+        ( const FPack& fp, strf::print_preview<ReqSize, true>& preview
+        , const strf::detail::simple_tuple<Args...>& args
+        , std::ptrdiff_t split_pos
+        , strf::alignment_format_data afmt )
+        : _split_pos(split_pos)
+        , _afmt(afmt)
+        , _encoding(_get_facet<strf::encoding_c<CharT>>(fp))
+        , _enc_err(_get_facet<strf::encoding_error_c>(fp))
+        , _allow_surr(_get_facet<strf::surrogate_policy_c>(fp))
+    {
+        if (_afmt.width < 0) {
+            _afmt.width = 0;
+        }
+        strf::width_t wmax = _afmt.width;
+        strf::width_t diff = 0;
+        if (preview.remaining_width() > _afmt.width) {
+            wmax = preview.remaining_width();
+            diff = preview.remaining_width() - _afmt.width;
+        }
+        strf::print_preview<ReqSize, true> p { wmax };
+        new (_printers_ptr()) _printers_tuple { fp, p, args }; // todo: what if this throws ?
+        if (p.remaining_width() > diff) {
+            _fillcount = (p.remaining_width() - diff).round();
+        }
+        width_t width = _fillcount + wmax - p.remaining_width();
+        preview.subtract_width(width);
+        STRF_IF_CONSTEXPR (ReqSize)
+        {
+            preview.add_size(p.get_size());
+            if (_fillcount > 0) {
+                preview.add_size(_fillcount * _encoding.char_size(_afmt.fill));
+            }
+        }
+    }
 
-	STRF_HD ~aligned_join_printer_impl()
-	{
-		_printers_ptr()->~_printers_tuple();
-	}
+    STRF_HD ~aligned_join_printer_impl()
+    {
+        _printers_ptr()->~_printers_tuple();
+    }
 
-	STRF_HD void print_to(strf::basic_outbuf<CharT>& ob) const override
-	{
-		switch (_afmt.alignment) {
-		case strf::text_alignment::left: {
-			strf::detail::write(ob, _printers());
-			_write_fill(ob, _fillcount);
-			break;
-		}
-		case strf::text_alignment::right: {
-			_write_fill(ob, _fillcount);
-			strf::detail::write(ob, _printers());
-			break;
-		}
-		case strf::text_alignment::split: {
-			_print_split(ob);
-			break;
-		}
-		default: {
-			STRF_ASSERT(_afmt.alignment == strf::text_alignment::center);
-			auto half_fillcount = _fillcount >> 1;
-			_write_fill(ob, half_fillcount);
-			strf::detail::write(ob, _printers());
-			;
-			_write_fill(ob, _fillcount - half_fillcount);
-			break;
-		}
-		}
-	}
+    STRF_HD void print_to(strf::basic_outbuf<CharT>& ob) const override
+    {
+        switch (_afmt.alignment) {
+            case strf::text_alignment::left: {
+                strf::detail::write(ob, _printers());
+                _write_fill(ob, _fillcount);
+                break;
+            }
+            case strf::text_alignment::right: {
+                _write_fill(ob, _fillcount);
+                strf::detail::write(ob, _printers());
+                break;
+            }
+            case strf::text_alignment::split: {
+                _print_split(ob);
+                break;
+            }
+            default: {
+                STRF_ASSERT(_afmt.alignment == strf::text_alignment::center);
+                auto half_fillcount = _fillcount >> 1;
+                _write_fill(ob, half_fillcount);
+                strf::detail::write(ob, _printers());
+                _write_fill(ob, _fillcount - half_fillcount);
+                break;
+            }
+        }
+    }
 
 private:
 
-	using _printers_tuple_storage = typename std::aligned_storage_t
+    using _printers_tuple_storage = typename std::aligned_storage_t
 #if defined(_MSC_VER)
-	<sizeof(std::tuple<Printers...>), alignof(strf::printer<CharT>)>;
+    <sizeof(std::tuple<Printers...>), alignof(strf::printer<CharT>)>;
 #else
-	<sizeof(_printers_tuple), alignof(_printers_tuple)>;
+    <sizeof(_printers_tuple), alignof(_printers_tuple)>;
 #endif
-	_printers_tuple_storage _pool;
-	std::ptrdiff_t _split_pos;
-	strf::alignment_format_data _afmt;
-	const strf::encoding<CharT> _encoding;
-	strf::width_t _width;
-	std::int16_t _fillcount = 0;
-	strf::encoding_error _enc_err;
-	strf::surrogate_policy _allow_surr;
+    _printers_tuple_storage _pool;
+    std::ptrdiff_t _split_pos;
+    strf::alignment_format_data _afmt;
+    const strf::encoding<CharT> _encoding;
+    strf::width_t _width;
+    std::int16_t _fillcount = 0;
+    strf::encoding_error _enc_err;
+    strf::surrogate_policy _allow_surr;
 
-	STRF_HD _printers_tuple * _printers_ptr()
-	{
-		return reinterpret_cast<_printers_tuple*>(&_pool);
-	}
-	STRF_HD const _printers_tuple& _printers() const
-	{
-		return *reinterpret_cast<const _printers_tuple*>(&_pool);
-	}
+    STRF_HD _printers_tuple * _printers_ptr()
+    {
+        return reinterpret_cast<_printers_tuple*>(&_pool);
+    }
+    STRF_HD const _printers_tuple& _printers() const
+    {
+        return *reinterpret_cast<const _printers_tuple*>(&_pool);
+    }
 
-	template <typename Category, typename FPack>
-	static decltype(auto) STRF_HD _get_facet(const FPack& fp)
-	{
-		return fp.template get_facet<Category, strf::aligned_join_t>();
-	}
+    template <typename Category, typename FPack>
+    static decltype(auto) STRF_HD _get_facet(const FPack& fp)
+    {
+        return fp.template get_facet<Category, strf::aligned_join_t>();
+    }
 
-	STRF_HD std::size_t _fill_length() const
-	{
-		if (_fillcount > 0) {
-			return _fillcount * _encoding.char_size(_afmt.fill);
-		}
-		return 0;
-	}
+    STRF_HD std::size_t _fill_length() const
+    {
+        if (_fillcount > 0) {
+            return _fillcount * _encoding.char_size(_afmt.fill);
+        }
+        return 0;
+    }
 
-	STRF_HD void _write_fill(strf::basic_outbuf<CharT>& ob, int count) const
-	{
-		_encoding.encode_fill(ob, count, _afmt.fill, _enc_err, _allow_surr);
-	}
+    STRF_HD void _write_fill(strf::basic_outbuf<CharT>& ob, int count) const
+    {
+        _encoding.encode_fill(ob, count, _afmt.fill, _enc_err, _allow_surr);
+    }
 
-	STRF_HD void _print_split(strf::basic_outbuf<CharT>& ob) const;
+    STRF_HD void _print_split(strf::basic_outbuf<CharT>& ob) const;
 };
 
 template<typename CharT, typename ... Printers>
 STRF_HD void aligned_join_printer_impl<CharT, Printers...>::_print_split(strf::basic_outbuf<CharT>& ob) const
 {
-	strf::detail::print_split(_printers(), ob, _encoding, _fillcount, _afmt.fill, _split_pos, _enc_err,
-		_allow_surr);
+    strf::detail::print_split( _printers(), ob, _encoding, _fillcount, _afmt.fill
+                             , _split_pos, _enc_err, _allow_surr );
 }
 
 template<typename CharT, typename FPack, typename Preview, typename ... Args>
 using aligned_join_printer_impl_of
 = aligned_join_printer_impl
-< CharT
-, decltype(make_printer<CharT>
-	( strf::rank<5>()
-		, std::declval<const FPack&>()
-		, std::declval<strf::print_preview<Preview::size_required, true>&>()
-		, std::declval<const Args&>() )) ... >;
+    < CharT
+    , decltype
+        ( make_printer<CharT>
+            ( strf::rank<5>()
+            , std::declval<const FPack&>()
+            , std::declval<strf::print_preview<Preview::size_required, true>&>()
+            , std::declval<const Args&>() )) ... >;
 
 template<typename CharT, typename FPack, typename Preview, typename ... Args>
-class aligned_join_printer: public strf::detail::aligned_join_printer_impl_of<CharT, FPack, Preview, Args...> {
-	using _aligned_join_impl
-	= strf::detail::aligned_join_printer_impl_of
-	<CharT, FPack, Preview, Args...>;
+class aligned_join_printer
+    : public strf::detail::aligned_join_printer_impl_of<CharT, FPack, Preview, Args...>
+{
+    using _aligned_join_impl = strf::detail::aligned_join_printer_impl_of
+        <CharT, FPack, Preview, Args...>;
 
 public:
 
-	STRF_HD aligned_join_printer(const FPack& fp, Preview& preview, const strf::detail::simple_tuple<Args...>& args,
-		std::ptrdiff_t split_pos, strf::alignment_format_data afmt) :
-		_aligned_join_impl(fp, preview, args, split_pos, afmt)
-	{
-	}
+    STRF_HD aligned_join_printer
+        ( const FPack& fp
+        , Preview& preview
+        , const strf::detail::simple_tuple<Args...>& args
+        , std::ptrdiff_t split_pos
+        , strf::alignment_format_data afmt )
+        : _aligned_join_impl(fp, preview, args, split_pos, afmt)
+    {
+    }
 
-	STRF_HD aligned_join_printer(const aligned_join_printer&) = default;
+    STRF_HD aligned_join_printer(const aligned_join_printer&) = default;
 
-	virtual STRF_HD ~aligned_join_printer()
-	{
-	}
+    virtual STRF_HD ~aligned_join_printer()
+    {
+    }
 };
 
 template<typename CharT, typename ... Printers>
 class join_printer_impl: public printer<CharT> {
 public:
 
-	template<typename FPack, typename Preview, typename ... Args>
-	STRF_HD join_printer_impl(const FPack& fp, Preview& preview, const strf::detail::simple_tuple<Args...>& args) :
-		_printers { fp, preview, args }
-	{
-	}
+    template<typename FPack, typename Preview, typename ... Args>
+    STRF_HD join_printer_impl
+        ( const FPack& fp
+        , Preview& preview
+        , const strf::detail::simple_tuple<Args...>& args )
+        : _printers { fp, preview, args }
+    {
+    }
 
-	STRF_HD ~join_printer_impl()
-	{
-	}
+    STRF_HD ~join_printer_impl()
+    {
+    }
 
-	STRF_HD void print_to(strf::basic_outbuf<CharT>& ob) const override
-	{
-		strf::detail::write(ob, _printers);
-	}
+    STRF_HD void print_to(strf::basic_outbuf<CharT>& ob) const override
+    {
+        strf::detail::write(ob, _printers);
+    }
 
 private:
 
-	strf::detail::printers_tuple<CharT, Printers...> _printers;
+    strf::detail::printers_tuple<CharT, Printers...> _printers;
 };
 
 template<typename CharT, typename FPack, typename Preview, typename ... Args>
-class join_printer: public strf::detail::join_printer_impl<CharT, decltype(make_printer<CharT>( strf::rank<5>()
-		, std::declval<const FPack&>()
-		, std::declval<Preview&>()
-		, std::declval<const Args&>() )) ...> {
-	using _join_impl
-	= strf::detail::join_printer_impl
-	< CharT
-	, decltype(make_printer<CharT>( strf::rank<5>()
-			, std::declval<const FPack&>()
-			, std::declval<Preview&>()
-			, std::declval<const Args&>() )) ... >;
+class join_printer
+    : public strf::detail::join_printer_impl
+        < CharT
+        , decltype(make_printer<CharT>( strf::rank<5>()
+                                      , std::declval<const FPack&>()
+                                      , std::declval<Preview&>()
+                                      , std::declval<const Args&>() )) ...>
+{
+
+    using _join_impl = strf::detail::join_printer_impl
+        < CharT
+        , decltype(make_printer<CharT>( strf::rank<5>()
+                                      , std::declval<const FPack&>()
+                                      , std::declval<Preview&>()
+                                      , std::declval<const Args&>() )) ... >;
 public:
 
-	STRF_HD join_printer(const FPack& fp, Preview& preview, const strf::detail::simple_tuple<Args...>& args) :
-		_join_impl(fp, preview, args)
-	{
-	}
+    STRF_HD join_printer(const FPack& fp, Preview& preview, const strf::detail::simple_tuple<Args...>& args) :
+        _join_impl(fp, preview, args)
+    {
+    }
 
-	STRF_HD join_printer(const join_printer& cp) = default;
-	virtual STRF_HD ~join_printer()
-	{
-	}
+    STRF_HD join_printer(const join_printer& cp) = default;
+    virtual STRF_HD ~join_printer()
+    {
+    }
 };
 
 } // namespace detail
 
-template<typename CharT, typename FPack, typename Preview, bool SplitPosActive, typename ... Args>
-inline STRF_HD strf::detail::join_printer<CharT, FPack, Preview, Args...> make_printer(strf::rank<1>, const FPack& fp,
-	Preview& preview,
-	const strf::value_with_format<strf::detail::simple_tuple<Args...>, strf::split_pos_format<SplitPosActive>,
-		strf::alignment_format_q<false> > input)
+template< typename CharT
+        , typename FPack
+        , typename Preview
+        , bool SplitPosActive
+        , typename ... Args >
+inline STRF_HD strf::detail::join_printer<CharT, FPack, Preview, Args...> make_printer
+    ( strf::rank<1>
+    , const FPack& fp
+    , Preview& preview
+    , const strf::value_with_format< strf::detail::simple_tuple<Args...>
+                                   , strf::split_pos_format<SplitPosActive>
+                                   , strf::alignment_format_q<false> > input )
 {
-	return {fp, preview, input.value()};
+    return {fp, preview, input.value()};
 }
 
 template<typename ... Args>
-constexpr STRF_HD strf::value_with_format<strf::detail::simple_tuple<strf::detail::opt_val_or_cref<Args>...>,
-	strf::split_pos_format<false>, strf::alignment_format_q<false> > join(const Args& ... args)
+constexpr STRF_HD strf::value_with_format
+    < strf::detail::simple_tuple<strf::detail::opt_val_or_cref<Args>...>
+    , strf::split_pos_format<false>
+    , strf::alignment_format_q<false> >
+join(const Args& ... args)
 {
-	return strf::value_with_format<strf::detail::simple_tuple<strf::detail::opt_val_or_cref<Args>...>,
-		strf::split_pos_format<false>, strf::alignment_format_q<false> > { strf::detail::make_simple_tuple(
-		args...) };
+    return strf::value_with_format
+        < strf::detail::simple_tuple<strf::detail::opt_val_or_cref<Args>...>
+        , strf::split_pos_format<false>
+        , strf::alignment_format_q<false> >
+        { strf::detail::make_simple_tuple(args...) };
 }
 
 template<typename CharT, typename FPack, typename Preview, bool SplitPosActive, typename ... Args>
-inline STRF_HD strf::detail::aligned_join_printer<CharT, FPack, Preview, Args...> make_printer(strf::rank<1>,
-	const FPack& fp, Preview& preview,
-	const strf::value_with_format<strf::detail::simple_tuple<Args...>, strf::split_pos_format<SplitPosActive>,
-		strf::alignment_format_q<true> > input)
+inline STRF_HD strf::detail::aligned_join_printer<CharT, FPack, Preview, Args...> make_printer
+    ( strf::rank<1>
+    , const FPack& fp
+    , Preview& preview
+    , const strf::value_with_format
+        < strf::detail::simple_tuple<Args...>
+        , strf::split_pos_format<SplitPosActive>
+        , strf::alignment_format_q<true> > input )
 {
-	return {fp, preview, input.value(), input.split_pos()
-		, input.get_alignment_format_data()};
+    return { fp, preview, input.value(), input.split_pos()
+           , input.get_alignment_format_data() };
 }
 
-constexpr STRF_HD strf::aligned_join_t join_align(std::int16_t width, strf::text_alignment align,
-	char32_t fillchar = U' ', int split_pos = 0)
+constexpr STRF_HD strf::aligned_join_t join_align
+    ( std::int16_t width
+    , strf::text_alignment align
+    , char32_t fillchar = U' '
+    , int split_pos = 0 )
 {
-	return {width, align, fillchar, split_pos};
+    return {width, align, fillchar, split_pos};
 }
 
 constexpr STRF_HD strf::aligned_join_t join_center(std::int16_t width, char32_t fillchar = U' ') noexcept
 {
-	return {width, strf::text_alignment::center, fillchar, 0};
+    return {width, strf::text_alignment::center, fillchar, 0};
 }
 
 constexpr STRF_HD strf::aligned_join_t join_left(std::int16_t width, char32_t fillchar = U' ') noexcept
 {
-	return {width, strf::text_alignment::left, fillchar, 0};
+    return {width, strf::text_alignment::left, fillchar, 0};
 }
 
 constexpr STRF_HD strf::aligned_join_t join_right(std::int16_t width, char32_t fillchar = U' ') noexcept
 {
-	return {width, strf::text_alignment::right, fillchar, 0};
+    return {width, strf::text_alignment::right, fillchar, 0};
 }
 
 constexpr STRF_HD strf::aligned_join_t join_split(std::int16_t width, char32_t fillchar,
-	std::ptrdiff_t split_pos) noexcept
+    std::ptrdiff_t split_pos) noexcept
 {
-	return {width, strf::text_alignment::split, fillchar, split_pos};
+    return {width, strf::text_alignment::split, fillchar, split_pos};
 }
 
 constexpr STRF_HD strf::aligned_join_t join_split(std::int16_t width, std::ptrdiff_t split_pos) noexcept
 {
-	return {width, strf::text_alignment::split, U' ', split_pos};
+    return {width, strf::text_alignment::split, U' ', split_pos};
 }
 
 STRF_NAMESPACE_END

--- a/include/strf/detail/input_types/join.hpp
+++ b/include/strf/detail/input_types/join.hpp
@@ -33,10 +33,6 @@ public:
         : _pos(pos)
     {
     }
-    constexpr STRF_HD split_pos_format_fn(const split_pos_format_fn& other) noexcept
-        : split_pos_format_fn(other._pos)
-    {
-    }
 
     template <bool B, typename U>
     constexpr STRF_HD explicit split_pos_format_fn
@@ -73,9 +69,6 @@ public:
     constexpr STRF_HD split_pos_format_fn() noexcept
     {
     }
-    constexpr STRF_HD split_pos_format_fn(const split_pos_format_fn& other) noexcept
-    {
-    }
 
     template<typename U>
     constexpr STRF_HD explicit split_pos_format_fn(const strf::split_pos_format_fn<false, U>&) noexcept
@@ -84,9 +77,9 @@ public:
 
     constexpr STRF_HD _adapted_derived_type split_pos(std::ptrdiff_t pos) const noexcept
     {
-        return {static_cast<const T&>(*this)
-            , strf::tag<strf::split_pos_format<true>> {}
-            , pos};
+        return { static_cast<const T&>(*this)
+               , strf::tag<strf::split_pos_format<true>> {}
+               , pos};
     }
 
     constexpr STRF_HD std::ptrdiff_t split_pos() const noexcept
@@ -367,8 +360,6 @@ public:
     {
     }
 
-    STRF_HD aligned_join_printer(const aligned_join_printer&) = default;
-
     virtual STRF_HD ~aligned_join_printer()
     {
     }
@@ -419,12 +410,13 @@ class join_printer
                                       , std::declval<const Args&>() )) ... >;
 public:
 
-    STRF_HD join_printer(const FPack& fp, Preview& preview, const strf::detail::simple_tuple<Args...>& args) :
-        _join_impl(fp, preview, args)
+    STRF_HD join_printer( const FPack& fp
+                        , Preview& preview
+                        , const strf::detail::simple_tuple<Args...>& args )
+        : _join_impl(fp, preview, args)
     {
     }
 
-    STRF_HD join_printer(const join_printer& cp) = default;
     virtual STRF_HD ~join_printer()
     {
     }

--- a/include/strf/detail/input_types/string.hpp
+++ b/include/strf/detail/input_types/string.hpp
@@ -27,11 +27,6 @@ public:
     {
     }
 
-    constexpr STRF_HD simple_string_view(const simple_string_view& other) noexcept
-        : simple_string_view(other._begin, other._len)
-    {
-    }
-
     STRF_CONSTEXPR_CHAR_TRAITS
     STRF_HD simple_string_view(const CharIn* str) noexcept
         : _begin(str)
@@ -83,13 +78,9 @@ class no_cv_format_fn
 {
 public:
 
-        constexpr STRF_HD no_cv_format_fn() noexcept
+    constexpr STRF_HD no_cv_format_fn() noexcept
     {
     }
-
-        constexpr STRF_HD no_cv_format_fn(const no_cv_format_fn& other) noexcept
-    {
-       }
 
     template <typename U>
     constexpr STRF_HD explicit no_cv_format_fn
@@ -151,11 +142,7 @@ public:
 template <typename CharT, typename T>
 struct cv_format_fn
 {
-        constexpr STRF_HD cv_format_fn() noexcept
-    {
-    }
-
-        constexpr STRF_HD cv_format_fn(const cv_format_fn& other) noexcept
+    constexpr STRF_HD cv_format_fn() noexcept
     {
     }
 

--- a/include/strf/detail/output_types/char_ptr.hpp
+++ b/include/strf/detail/output_types/char_ptr.hpp
@@ -29,9 +29,6 @@ public:
         STRF_ASSERT(dest < dest_end);
     }
 
-    constexpr STRF_HD
-    basic_cstr_writer_creator(const basic_cstr_writer_creator&) = default;
-
     STRF_HD basic_cstr_writer<CharT> create() const
     {
         return basic_cstr_writer<CharT>{_dest, _dest_end};

--- a/include/strf/detail/printers_tuple.hpp
+++ b/include/strf/detail/printers_tuple.hpp
@@ -22,15 +22,6 @@ struct indexed_obj
     {
     }
 
-    constexpr STRF_HD indexed_obj(const indexed_obj& other)
-        : obj(other.obj)
-    {
-    }
-    constexpr STRF_HD indexed_obj(indexed_obj&& other)
-        : obj(other.obj)
-    {
-    }
-
     T obj;
 };
 
@@ -56,15 +47,6 @@ public:
     template <typename ... Args>
     constexpr STRF_HD explicit simple_tuple_impl(simple_tuple_from_args, Args&& ... args)
         : indexed_obj<I, T>(args)...
-    {
-    }
-
-    constexpr STRF_HD simple_tuple_impl(const simple_tuple_impl& other)
-        : indexed_obj<I, T>(other) ...
-    {
-       }
-    constexpr STRF_HD simple_tuple_impl(simple_tuple_impl&& other)
-        : indexed_obj<I, T>(other) ...
     {
     }
 
@@ -188,15 +170,6 @@ public:
         , Preview& preview
         , const strf::detail::simple_tuple<Args...>& args )
         : indexed_printer<I, Printers>(fp, preview, args.template get<I>()) ...
-    {
-    }
-
-    STRF_HD printers_tuple_impl(const printers_tuple_impl& fp)
-        : detail::indexed_printer<I, Printers>(fp)...
-    {
-    }
-    STRF_HD printers_tuple_impl(printers_tuple_impl&& fp)
-        : detail::indexed_printer<I, Printers>(fp)...
     {
     }
 

--- a/include/strf/detail/single_byte_encodings.hpp
+++ b/include/strf/detail/single_byte_encodings.hpp
@@ -339,20 +339,20 @@ ForwardIt STRF_HD lower_bound
     return std::lower_bound(first, last, value, comp);
 #else
     auto search_range_length { last - first };
-    	// We don't have the equivalent of std::distance on the device-side
+        // We don't have the equivalent of std::distance on the device-side
 
     ForwardIt iter;
     while (search_range_length > 0) {
-    	auto half_range_length = search_range_length/2;
+        auto half_range_length = search_range_length/2;
         iter = first;
         iter += half_range_length;
         if (comp(*iter, value)) {
             first = ++iter;
             search_range_length -= (half_range_length + 1);
-            	// the extra +1 is since we've just checked the midpoint
+                // the extra +1 is since we've just checked the midpoint
         }
         else {
-        	search_range_length = half_range_length;
+            search_range_length = half_range_length;
         }
     }
     return first;

--- a/include/strf/detail/standard_lib_functions.hpp
+++ b/include/strf/detail/standard_lib_functions.hpp
@@ -122,7 +122,7 @@ inline constexpr STRF_HD const T&
 max(const T& lhs, const T& rhs) noexcept
 {
 #if !defined(__CUDA_ARCH__) && STRF_PREFER_STD_LIBRARY_STRING_FUNCTIONS
-	return std::max(lhs, rhs);
+    return std::max(lhs, rhs);
 #elif __CUDA_ARCH__
     return max(lhs, rhs);
 #else

--- a/include/strf/detail/utf_encodings.hpp
+++ b/include/strf/detail/utf_encodings.hpp
@@ -49,7 +49,8 @@ inline STRF_HD void do_repeat_sequence
     , std::size_t count
     , simple_array<CharT, N> seq )
 {
-	strf::detail::str_fill_n(reinterpret_cast<simple_array<CharT, N>*>(dest), count, seq);
+    auto reinterpreted_dest = reinterpret_cast<simple_array<CharT, N>*>(dest);
+    strf::detail::str_fill_n(reinterpreted_dest, count, seq);
 }
 
 template <typename CharT, std::size_t N>

--- a/include/strf/facets_pack.hpp
+++ b/include/strf/facets_pack.hpp
@@ -240,16 +240,6 @@ class fpe_wrapper
 
 public:
 
-    constexpr STRF_HD fpe_wrapper(const fpe_wrapper& other)
-        : _facet(other._facet)
-    {
-    }
-
-    constexpr STRF_HD fpe_wrapper(fpe_wrapper&& other)
-        : _facet(std::move(other._facet))
-    {
-    }
-
     template
         < typename F = Facet
         , typename = std::enable_if_t<std::is_copy_constructible<F>::value> >
@@ -295,16 +285,6 @@ class fpe_wrapper<Rank, strf::constrained_fpe<Filter, FPE>>
 
 public:
 
-    constexpr STRF_HD fpe_wrapper(const fpe_wrapper& other)
-       : _fpe(other._fpe)
-    {
-    }
-
-    constexpr STRF_HD fpe_wrapper(fpe_wrapper&& other)
-        : _fpe(std::move(other._fpe))
-    {
-    }
-
     template
         < typename F = FPE
         , typename = std::enable_if_t<std::is_copy_constructible<F>::value > >
@@ -342,15 +322,6 @@ class fpe_wrapper<Rank, const FPE&>
 {
 public:
 
-    constexpr STRF_HD fpe_wrapper(const fpe_wrapper& other)
-        : _fpe(other._fpe)
-    {
-    }
-    constexpr STRF_HD fpe_wrapper(fpe_wrapper&& other)
-        : _fpe(std::move(other._fpe))
-    {
-    }
-
     constexpr STRF_HD fpe_wrapper(const FPE& fpe)
         : _fpe(fpe)
     {
@@ -386,18 +357,9 @@ class fpe_wrapper<Rank, strf::facets_pack<FPE...>>
 
 public:
 
-    constexpr STRF_HD fpe_wrapper(const fpe_wrapper& other)
-        : _fp(other._fp)
-    {
-    }
-    constexpr STRF_HD fpe_wrapper(fpe_wrapper&& other)
-        : _fp(std::move(other._fp))
-    {
-    }
-
     template
         < typename FP = _fp_type
-        , typename = std::enable_if_t<std::is_copy_constructible<FP>::value> >
+        , std::enable_if_t<std::is_copy_constructible<FP>::value, int> = 0>
     constexpr STRF_HD fpe_wrapper(const _fp_type& fp)
         : _fp(fp)
     {
@@ -405,7 +367,7 @@ public:
 
     template
         < typename FP = _fp_type
-        , typename = std::enable_if_t<std::is_move_constructible<FP>::value> >
+        , std::enable_if_t<std::is_move_constructible<FP>::value, int> = 0>
     constexpr STRF_HD fpe_wrapper(_fp_type&& fp)
         : _fp(std::move(fp))
     {
@@ -500,17 +462,6 @@ template <std::size_t RankN>
 class facets_pack_base<RankN>
 {
 public:
-    constexpr STRF_HD facets_pack_base(const facets_pack_base&)
-    {
-    }
-
-    constexpr STRF_HD facets_pack_base(facets_pack_base&&)
-    {
-    }
-
-    constexpr STRF_HD facets_pack_base()
-    {
-    }
 
     constexpr STRF_HD void do_get_facet() const
     {
@@ -531,22 +482,6 @@ class facets_pack_base<RankN, TipFPE, OthersFPE...>
         < RankN + 1, OthersFPE...>;
 
 public:
-
-    constexpr STRF_HD facets_pack_base(const facets_pack_base& other)
-        : strf::detail::fpe_wrapper
-        < strf::rank<RankN>, TipFPE >(other)
-        , strf::detail::facets_pack_base
-        < RankN + 1, OthersFPE...>(other)
-    {
-    }
-
-    constexpr STRF_HD facets_pack_base(facets_pack_base&& other)
-        : strf::detail::fpe_wrapper
-        < strf::rank<RankN>, TipFPE >(std::move(other))
-        , strf::detail::facets_pack_base
-        < RankN + 1, OthersFPE...>(std::move(other))
-    {
-    }
 
     template< typename T = TipFPE
             , typename B = _base_others_fpe
@@ -651,23 +586,12 @@ class constrained_fpe
 {
 public:
 
-    static_assert( strf::is_constrainable_v<FPE>
-                 , "Not constrainable");
+    static_assert(strf::is_constrainable_v<FPE>, "FPE not constrainable");
 
     template
         < typename F = FPE
         , typename = std::enable_if_t<std::is_default_constructible<F>::value> >
     constexpr STRF_HD explicit constrained_fpe()
-    {
-    }
-
-    constexpr STRF_HD constrained_fpe(const constrained_fpe& other)
-        : _fpe(other._fpe)
-    {
-    }
-
-    constexpr STRF_HD constrained_fpe(constrained_fpe&& other)
-        : _fpe(std::move(other._fpe))
     {
     }
 
@@ -686,9 +610,6 @@ public:
         : _fpe(std::forward<U>(arg))
     {
     }
-
-    constexpr STRF_HD constrained_fpe& operator=(const constrained_fpe&) = delete;
-    constexpr STRF_HD constrained_fpe& operator=(constrained_fpe&&) = delete;
 
     constexpr STRF_HD const FPE& get() const
     {
@@ -714,18 +635,6 @@ template <>
 class facets_pack<>
 {
 public:
-    constexpr STRF_HD facets_pack(const facets_pack&)
-    {
-    }
-    constexpr STRF_HD facets_pack(facets_pack&&)
-    {
-    }
-    constexpr STRF_HD facets_pack()
-    {
-    }
-
-    STRF_HD facets_pack& operator=(const facets_pack&) = delete;
-    STRF_HD facets_pack& operator=(facets_pack&&) = delete;
 
     template <typename Category, typename Tag>
     STRF_HD decltype(auto) get_facet() const
@@ -751,16 +660,6 @@ class facets_pack: private strf::detail::facets_pack_base_t<FPE...>
 
 public:
 
-    constexpr STRF_HD facets_pack(const facets_pack& other)
-        : _base_type(other)
-    {
-    }
-
-    constexpr STRF_HD facets_pack(facets_pack&& other)
-        : _base_type(std::move(other))
-    {
-    }
-
     template
         < bool Dummy = true
         , typename = std::enable_if_t
@@ -780,10 +679,6 @@ public:
         : _base_type(std::forward<U>(fpe)...)
     {
     }
-
-    STRF_HD facets_pack& operator=(const facets_pack&) = delete;
-
-    STRF_HD facets_pack& operator=(facets_pack&&) = delete;
 
     template <typename Category, typename Tag>
     constexpr STRF_HD decltype(auto) get_facet() const

--- a/include/strf/outbuf.hpp
+++ b/include/strf/outbuf.hpp
@@ -48,7 +48,7 @@ public:
     underlying_outbuf& STRF_HD operator=(const underlying_outbuf&) = delete;
     underlying_outbuf& STRF_HD operator=(underlying_outbuf&&) = delete;
 
-        virtual STRF_HD ~underlying_outbuf() { };
+    virtual STRF_HD ~underlying_outbuf() { };
 
     STRF_HD char_type* pos() const noexcept
     {

--- a/include/strf/printer.hpp
+++ b/include/strf/printer.hpp
@@ -234,10 +234,6 @@ public:
     {
     }
 
-    STRF_HD width_preview(const width_preview& other) noexcept
-    {
-    }
-
     constexpr STRF_HD void subtract_width(strf::width_t)
     {
     }
@@ -298,10 +294,6 @@ public:
     {
     }
 
-    constexpr STRF_HD size_preview(const size_preview&) noexcept
-    {
-    }
-
     constexpr STRF_HD void add_size(std::size_t)
     {
     }
@@ -331,11 +323,6 @@ public:
     }
 
     constexpr STRF_HD print_preview() noexcept
-    {
-    }
-    constexpr STRF_HD print_preview(const print_preview& other)
-        : strf::size_preview<SizeRequired>(other)
-        , strf::width_preview<WidthRequired>(other)
     {
     }
 };

--- a/include/strf/width_t.hpp
+++ b/include/strf/width_t.hpp
@@ -52,7 +52,6 @@ public:
     //     }
     // }
 
-
     constexpr STRF_HD width_t(from_underlying_tag, std::int32_t v) noexcept
         : _value(v)
     {


### PR DESCRIPTION
I removed the declarations of the default copy and move constructors.
I think this has the same effect as defining them with ` = default;`,
so theoretically it shouldn't work. 
But could you test on device side anyway ?

If this doesn't work, then I believe issue #17 is unsolvable. 
